### PR TITLE
Change the cert_project_id for kogito-operator

### DIFF
--- a/operators/kogito-operator/ci.yaml
+++ b/operators/kogito-operator/ci.yaml
@@ -1,4 +1,4 @@
 ---
 # Operator level configuration
-cert_project_id: "5e6009f8c74e853a79f6ca05"
+cert_project_id: "5f68c70e7115dbd1183ccab5"
 merge: false


### PR DESCRIPTION
This project is guaranteed to exist in all preprod environments when the
database is reseeded.

Related to: https://github.com/redhat-openshift-ecosystem/operator-pipelines/pull/95