### PR TITLE
[ISV-1444] Remove EOL OCP 4.6 from e2e-test-operator

### DIFF
--- a/operators/test-e2e-operator/0.0.7/metadata/annotations.yaml
+++ b/operators/test-e2e-operator/0.0.7/metadata/annotations.yaml
@@ -15,4 +15,4 @@ annotations:
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
   # OpenShift annotations
-  com.redhat.openshift.versions: v4.6-v4.9
+  com.redhat.openshift.versions: v4.7-v4.9


### PR DESCRIPTION
The pipeline will soon begin failing if certification is attempted for
an EOL version of OpenShift.