### PR TITLE
Remove EOL version from test bundle

### DIFF
--- a/operators/test-e2e-operator/0.0.8/metadata/annotations.yaml
+++ b/operators/test-e2e-operator/0.0.8/metadata/annotations.yaml
@@ -15,4 +15,4 @@ annotations:
   operators.operatorframework.io.test.config.v1: tests/scorecard/
 
   # OpenShift annotations
-  com.redhat.openshift.versions: v4.7-v4.10
+  com.redhat.openshift.versions: v4.10


### PR DESCRIPTION
The 4.7 is now EOL and operator can't be certified. I bumped it to >=4.10 to have enough time for next occurrence.

TODO: Fix the pipeline to not fail when EOL date is reached and the bundle supports at least one supported version.